### PR TITLE
Attempt to fix split up/down Clojure migrations.

### DIFF
--- a/src/coast/migrations.clj
+++ b/src/coast/migrations.clj
@@ -117,7 +117,7 @@
              :filename filename}
       (let [f (load-file filename-with-path)
             ;; Figure out what the migration's given us...
-            {:syms [down change] (-> f meta :ns .getName ns-publics)
+            {:syms [down change]} (-> f meta :ns .getName ns-publics)
             output (cond
                      down   (do
                               (reset! coast.db.migrations/rollback? false) ;; don't auto-undo anything,


### PR DESCRIPTION
Currently, contrary to the docs, using split up/down Clojure migrations does not run as intended; instead, it runs the *last defined function in the migration file*, which is often going to be `down` by convention.

This is an attempt to guess the intent of a migration by checking for `change` functions explicitly, running it if found, and trying to run the `up` and `down` migrations otherwise. It also fixes a potential issue with `down` migrations being inverted by code intended to invert `change` migrations automatically.

This is an ugly draft, so more would need to be done here to proof it, I expect.